### PR TITLE
RedwoodSDK baseline scaffold for migration

### DIFF
--- a/.docs/blueprints/overview.md
+++ b/.docs/blueprints/overview.md
@@ -1,0 +1,41 @@
+# 2000ft View
+
+This repository is a very small static website for `peterp.org`, currently implemented as a single hand-written HTML page plus a `CNAME` file for custom-domain hosting. The README identifies it as a kindling dogfood fork of `peterp/peterp.github.io`, so contributors here are working in a testbed for the kindling agent harness rather than the upstream site itself. At this snapshot, the repo is not yet a RedwoodSDK application; it is a minimal baseline that later migration tasks will expand.
+
+# System Flow
+
+The current runtime path is simple and file-based. The host serves `index.html`, which contains the entire page structure, content, and inline CSS. There is no build step, package manager, application server, or generated asset pipeline in the repository.
+
+The domain mapping is represented by `CNAME`. That suggests the site is intended to be published as a static host with a custom domain, but the repository does not include deployment configuration beyond that file.
+
+Operational task tracking for agent work lives under `.kindling/board/doing/`. The active card in that directory records the current migration task metadata, but it is not part of the website runtime path.
+
+# Directory Map
+
+- `.git/` — Git metadata for the repository.
+- `.github/` — GitHub repository metadata; currently includes a pull request template.
+- `.kindling/` — kindling harness state for local task tracking, including board entries.
+
+# Key Abstractions
+
+`index.html` is the primary application artifact. It combines document structure, user-facing copy, external links, and the only styling in one file. Any current site behavior or content change flows through this file.
+
+`CNAME` is the repository’s domain binding artifact. Its presence indicates the static site is intended to answer for `peterp.org`, and it is the only hosting-related file checked into the repo at this point.
+
+The kindling task card under `.kindling/board/doing/2026-04-20-1206-scaffold-redwoodsdk-baseline-e628.md` is the current work-tracking abstraction for this fork. It stores the task brief, status fields, and progress log for the in-flight scaffold effort.
+
+`README.md` is the human-authored project description. It explains that this repository is a dogfood fork used to exercise kindling against a live example and that the real site lives upstream.
+
+# Conventions Observed
+
+- The live site is currently maintained as a single static HTML document at the repository root.
+- Styling is inline inside the HTML document rather than split into separate asset files.
+- Repository-level metadata is sparse and human-authored; there is no generated project scaffolding yet.
+- Kindling work items are stored as Markdown files under `.kindling/board/...`.
+
+# Known Unknowns
+
+- Build and deployment flow are not fully represented in the repo; aside from `CNAME`, there is no checked-in publish or hosting configuration.
+- Testing strategy is unclear because there are no tests, test runner config, or package manifests yet.
+- Branching and release conventions are unclear from the checked-in files.
+- RedwoodSDK, pnpm, and Cloudflare Workers setup referenced by the current task brief are not present in this snapshot, so the future application structure is not yet visible from the codebase itself.

--- a/.kindling/board/doing/2026-04-20-1206-scaffold-redwoodsdk-baseline-e628.md
+++ b/.kindling/board/doing/2026-04-20-1206-scaffold-redwoodsdk-baseline-e628.md
@@ -1,0 +1,27 @@
+---
+status: doing
+labels: []
+created: "2026-04-20T10:07:22.965Z"
+started: "2026-04-20T10:07:22.965Z"
+completed: null
+github-pr: null
+github-comments: true
+no-pr: false
+depends-on: []
+---
+
+## Brief
+
+Scaffold RedwoodSDK Baseline
+
+## Checklist
+
+## Progress Log
+
+
+
+
+- [2026-04-20T10:11:08.388Z] [harness] This repo has almost no app structure yet, so the first step is to lock down the exact RedwoodSDK scaffold path before anything is generated. That keeps the first PR narrowly focused and makes the later boot verification clear and reliable.
+- [2026-04-20T10:09:04.276Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
+- [2026-04-20T10:09:03.536Z] [harness] Updated draft PR with context from priming (title=true, body=true)
+- [2026-04-20T10:07:24.222Z] [harness] Understanding your codebase so agents have architectural context...


### PR DESCRIPTION
Context: this draft PR is about introducing the RedwoodSDK application baseline for the `peterp.org` migration epic. The repo is currently just a minimal static site with `index.html`, `CNAME`, and sparse metadata, so the scaffold has to be created from scratch.

Planned work in this branch:
- add pnpm-managed app structure and dependencies
- establish RedwoodSDK entrypoints and local boot flow suitable for later Cloudflare Workers deployment
- keep the existing static page intact as the source of truth for future migration work
- keep this PR scaffold-only: no page-content port, no styling migration, no Wrangler config, no deploy workflow, and no agent-ci setup

The current repository state and task card indicate there is no existing `package.json`, lockfile, `src/` tree, or RedwoodSDK setup yet, so this work is the foundation for later migration steps rather than a content move. Domain registrar transfer and GitHub Pages cutover remain out of scope for this branch.