### PR TITLE
Cloudflare Workers runtime config for RedwoodSDK

### DIFF
--- a/.docs/blueprints/overview.md
+++ b/.docs/blueprints/overview.md
@@ -1,0 +1,30 @@
+# 2000ft View
+This repository is a kindling dogfood fork of `peterp/peterp.github.io`. It currently serves a simple personal homepage for Peter Pistorius, with a handful of external links and a short bio. The repo appears to be used primarily as a live test target for kindling workflows rather than as a large application codebase.
+
+# System Flow
+1. The site starts at `index.html` in the repository root.
+2. The document defines the full page structure inline, including metadata, content, and styles.
+3. There is no client-side application bundle, server entry point, or build pipeline visible in the current tree.
+4. Deployment context is implied by the `CNAME` file and the fork metadata, but no runtime config is currently present in the repo.
+
+# Directory Map
+- `.github/` - repository metadata for GitHub, currently only a pull request template.
+- `.kindling/` - local kindling task state created by the harness.
+
+# Key Abstractions
+- `index.html` - the entire rendered site lives in this file. It contains the page title, inline CSS, and the visible homepage content.
+- `CNAME` - indicates the custom domain associated with the site, `peterp.org`.
+- `README.md` - describes the repository as a kindling dogfood fork and points contributors back to the upstream project for the real site.
+- kindling task branch - the active branch name indicates the current task is focused on adding Cloudflare Workers runtime configuration for RedwoodSDK deployment.
+
+# Conventions Observed
+- The site is static and intentionally minimal.
+- Styling is inline in the HTML rather than split into separate assets.
+- GitHub-facing workflow guidance lives in `.github/PULL_REQUEST_TEMPLATE.md`.
+- The repository root is the deployment root; there is no subpackage layout visible.
+
+# Known Unknowns
+- No package manager manifest is present, so the build and test strategy is unclear.
+- No Cloudflare Workers or Wrangler configuration exists yet, so the intended deployment entry point is not explicit.
+- No RedwoodSDK source tree is visible in this checkout, so how the runtime config should connect to application code is not yet clear.
+- No CI configuration was found in the current tree.

--- a/.kindling/board/doing/2026-04-20-1228-add-cloudflare-workers-runtime-config-40f6.md
+++ b/.kindling/board/doing/2026-04-20-1228-add-cloudflare-workers-runtime-config-40f6.md
@@ -21,6 +21,8 @@ Add Cloudflare Workers Runtime Config
 
 
 
+
+- [2026-04-20T10:32:08.075Z] [harness] The setup work has been read and understood, so the next step is to put the deployment configuration in place. I’m moving straight into implementation now because the remaining task is to make the repo usable in Cloudflare, not to keep studying it.
 - [2026-04-20T10:30:58.755Z] [harness] Dispatching Developer for phase 1 (priming) of 5.
 - [2026-04-20T10:30:35.262Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
 - [2026-04-20T10:30:30.220Z] [harness] Updated draft PR with context from priming (title=true, body=true)

--- a/.kindling/board/doing/2026-04-20-1228-add-cloudflare-workers-runtime-config-40f6.md
+++ b/.kindling/board/doing/2026-04-20-1228-add-cloudflare-workers-runtime-config-40f6.md
@@ -1,0 +1,27 @@
+---
+status: doing
+labels: []
+created: "2026-04-20T10:28:43.073Z"
+started: "2026-04-20T10:28:43.073Z"
+completed: null
+github-pr: null
+github-comments: true
+no-pr: false
+depends-on: []
+---
+
+## Brief
+
+Add Cloudflare Workers Runtime Config
+
+## Checklist
+
+## Progress Log
+
+
+
+
+- [2026-04-20T10:30:58.755Z] [harness] Dispatching Developer for phase 1 (priming) of 5.
+- [2026-04-20T10:30:35.262Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
+- [2026-04-20T10:30:30.220Z] [harness] Updated draft PR with context from priming (title=true, body=true)
+- [2026-04-20T10:28:44.428Z] [harness] Understanding your codebase so agents have architectural context...

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "peterp-org"
+compatibility_date = "2026-04-20"
+
+[assets]
+directory = "."


### PR DESCRIPTION
Context for the deployment runtime work needed to run this repo in Cloudflare Workers.

This repository is currently a very small static-site fork rather than a RedwoodSDK app monorepo: the root only has `index.html`, `README.md`, `CNAME`, and GitHub metadata. There is no `package.json`, source tree, or existing Workers/Wrangler setup, so the work here is focused on establishing the deployment metadata the target environment expects.

The current direction is to add a minimal Workers configuration suitable for assets-based deployment, using a current `compatibility_date` and an assets directory rooted at `.`. I also persisted a repo blueprint under `.docs/blueprints/overview.md` so the current shape of the repo is recorded for the next pass.

What remains to be worked through is how this should evolve once a RedwoodSDK app structure exists, including whether a Worker entrypoint or additional bindings are needed beyond the static-assets baseline.