### PR TITLE
RedwoodSDK migration for peterp.org

### DIFF
--- a/.docs/blueprints/overview.md
+++ b/.docs/blueprints/overview.md
@@ -1,0 +1,40 @@
+# 2000ft View
+This repository is a very small personal-site fork for Peter Pistorius, currently serving as a single static HTML page for the `peterp.org` site. The active migration epic is to turn that one-file site into a RedwoodSDK application that runs on Cloudflare Workers, using pnpm and adding the expected worker and CI scaffolding along the way.
+
+# System Flow
+1. The site currently starts at [`index.html`](./index.html), which is the only application file in the repo.
+2. The browser loads the document directly as a static page, with content and styling defined inline.
+3. Navigation is just external links to Peter's Twitter, GitHub, and side projects; there is no app state, routing, or server-side logic yet.
+4. The repo also contains GitHub metadata for dogfooding and issue/PR workflow, plus a `CNAME` for the custom domain.
+5. The migration target, per issue #8, is a RedwoodSDK app with routes/components, styling moved into the framework, local dev verification, `wrangler.toml`, and a GitHub Actions deploy workflow.
+
+# Directory Map
+- `./` Root of the site repository; contains the HTML entry point, custom domain file, README, and GitHub workflow metadata.
+- `./.github/` GitHub-specific configuration, currently only a pull request template.
+- `./.kindling/` Kindling task state for the current dogfood run; not part of the site itself.
+- `./.docs/` Documentation area for repo-local planning artifacts; currently being introduced with the blueprint.
+
+# Key Abstractions
+`index.html` is the entire live product today. It combines document structure, copy, and presentation in one file, so it is the main source for the current site content and the first thing to port into any app framework.
+
+The `CNAME` file represents the custom domain setup for the site. It indicates the repository is tied to a hosted personal domain rather than just being an anonymous static demo.
+
+The Kindling task board under `.kindling/board/doing/` records the active migration task and its brief. It shows that this repo is being used as a live dogfood target, and that the current work is organized around the epic rather than a standalone feature request.
+
+The GitHub issue `redwoodjs/kindling-dogfood-peterp-site#8` is the authoritative task reference for the migration. It defines the target stack as RedwoodSDK on Cloudflare Workers, calls out pnpm as the package manager, and splits the work into scaffold, content port, styling, local verification, worker config, CI deployment, and agent-ci setup.
+
+The planned RedwoodSDK app is not present yet, but it is the central future abstraction for this repo. Based on the epic, it will be the place where routing, React components, framework styling, and Cloudflare Worker deployment configuration live.
+
+# Conventions Observed
+- The repository is extremely flat today; there is no existing `src/`, `app/`, or package manager structure.
+- Application content is currently authored directly in a single HTML file with inline CSS.
+- External links are used instead of internal routing.
+- The repo is set up as a dogfood fork, so task tracking lives alongside the site content.
+- The epic explicitly says to use `pnpm` for package management and scripts.
+
+# Known Unknowns
+- The RedwoodSDK scaffold does not exist yet, so the eventual source tree, route layout, and component boundaries are not visible in the current repo.
+- There is no `package.json`, so the build/dev/test commands are not yet defined here.
+- The local verification and deployment flow are not implemented yet; `wrangler.toml` and GitHub Actions are still pending.
+- The current hosting pipeline is unclear from the repo alone beyond the presence of `CNAME`.
+- No tests, linting setup, or formatter configuration are present in the current tree.

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -22,6 +22,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:54:25.582Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:53:59.233Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:53:32.311Z] [harness] Dispatching Developer for phase 1 (inventory) of 10.
 - [2026-04-20T10:53:02.567Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -21,6 +21,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:53:59.233Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:53:32.311Z] [harness] Dispatching Developer for phase 1 (inventory) of 10.
 - [2026-04-20T10:53:02.567Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
 - [2026-04-20T10:53:02.362Z] [harness] Updated draft PR with context from priming (title=true, body=true)

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -27,6 +27,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:56:44.630Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:56:17.945Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:55:54.045Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:55:25.222Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -23,6 +23,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:55:02.280Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:54:25.582Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:53:59.233Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:53:32.311Z] [harness] Dispatching Developer for phase 1 (inventory) of 10.

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -24,6 +24,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:55:25.222Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:55:02.280Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:54:25.582Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:53:59.233Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -28,6 +28,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:57:14.483Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:56:44.630Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:56:17.945Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:55:54.045Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -25,6 +25,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:55:54.045Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:55:25.222Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:55:02.280Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:54:25.582Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -26,6 +26,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:56:17.945Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:55:54.045Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:55:25.222Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:55:02.280Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -1,0 +1,27 @@
+---
+status: doing
+labels: []
+created: "2026-04-20T10:52:02.929Z"
+started: "2026-04-20T10:52:02.929Z"
+completed: null
+github-pr: null
+github-comments: true
+no-pr: false
+depends-on: []
+---
+
+## Brief
+
+Complete rwsdk Migration Epic
+
+## Checklist
+
+## Progress Log
+
+
+
+
+- [2026-04-20T10:53:32.311Z] [harness] Dispatching Developer for phase 1 (inventory) of 10.
+- [2026-04-20T10:53:02.567Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
+- [2026-04-20T10:53:02.362Z] [harness] Updated draft PR with context from priming (title=true, body=true)
+- [2026-04-20T10:52:04.353Z] [harness] Understanding your codebase so agents have architectural context...

--- a/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
+++ b/.kindling/board/doing/2026-04-20-1251-complete-rwsdk-migration-epic-3b2d.md
@@ -29,6 +29,8 @@ Complete rwsdk Migration Epic
 
 
 
+
+- [2026-04-20T10:57:34.805Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:57:14.483Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.
 - [2026-04-20T10:56:44.630Z] [harness] Dispatching Reviewer for phase 3 (port review) of 10.
 - [2026-04-20T10:56:17.945Z] [harness] Dispatching Developer for phase 2 (conversion plan) of 10.


### PR DESCRIPTION
## Context
This PR is part of the in-progress migration of `peterp.org` from a single-file static site to a RedwoodSDK app running on Cloudflare Workers.

The current repo is very small: `index.html` contains the whole site, with inline CSS and a short set of external links. There is no existing app scaffold, package manager setup, or worker config yet.

## Work in progress
The migration task will cover:
- scaffolding a RedwoodSDK project structure
- porting the existing content into routes and components
- moving the current styles into the app
- validating local development
- adding `wrangler.toml` / worker configuration
- adding a Cloudflare Workers deploy workflow
- installing `agent-ci` for GitHub Actions validation
- setting up `pnpm` scripts and package management

## Scope notes
The referenced epic explicitly excludes domain registrar transfer and cutting traffic over from GitHub Pages. This PR is focused on the application and deployment migration work inside the repo.