### PR TITLE
Port peterp.org into RedwoodSDK

### DIFF
--- a/.docs/blueprints/overview.md
+++ b/.docs/blueprints/overview.md
@@ -1,0 +1,40 @@
+# 2000ft View
+This repository currently hosts a very small personal-site fork for Peter Pistorius. The only user-facing artifact is a single static HTML page that introduces Peter, links to his Twitter and GitHub, and lists a handful of side projects. The repo is also a kindling dogfood target, so its current shape is intentionally minimal and the next major change is to port that presentation into a RedwoodSDK application without changing deployment wiring or worker configuration.
+
+# System Flow
+1. The browser opens `index.html` at the repository root.
+2. The document sets page metadata, title, and a small inline stylesheet.
+3. The body renders the entire experience in one pass: a greeting, bio text, social links, and a side-project list.
+4. There is no client-side routing, build step, server entry point, or runtime data fetching in the current version.
+5. The site is effectively static content served as-is.
+
+# Directory Map
+- `.github/` - GitHub workflow and pull request template metadata.
+- `.kindling/` - Harness state for the current task, including the active work item markdown.
+- `.docs/` - Documentation workspace; the `blueprints/` subtree is newly introduced here.
+- `.git/` - Git repository internals.
+- Root files:
+  - `README.md` - Short human-authored description of the fork and its purpose.
+  - `index.html` - The entire current site experience.
+  - `CNAME` - Custom domain configuration for the hosted site.
+
+# Key Abstractions
+- `index.html` is the only application surface today. It contains all visible content and the only styling rules, so it currently plays the role of both layout and presentation layer.
+- The hero greeting and bio paragraph define the primary content identity of the site. They establish the tone and are the first things a migration will need to preserve.
+- The social links section represents the persistent outbound navigation pattern on the page. It is simple, static, and hard-coded.
+- The side projects list is the only structured content block. It is an ordered list of external project links with brief descriptions.
+- The kindling task file under `.kindling/board/doing/` is the active orchestration artifact for this run, but it is not part of the user-facing site.
+
+# Conventions Observed
+- The site is fully static in the current state.
+- All content lives in one HTML file, with inline CSS rather than separated assets.
+- External links are written directly into the document; there is no content model or data layer.
+- There is no package manifest, source tree, or test suite in the repository snapshot.
+- The repository appears to target GitHub Pages-style hosting, indicated by the presence of `CNAME` and the upstream fork structure.
+
+# Known Unknowns
+- The RedwoodSDK app scaffold is not present yet, so the eventual route and component structure is unknown.
+- Build tooling, package manager choice, and source-language conventions are not declared in the current repository.
+- The deployment path for the future RedwoodSDK version is not visible here beyond the instruction not to change worker or deployment wiring.
+- Testing strategy is unclear because no tests or test runner configuration exist in the current tree.
+- The canonical content source for the peterp.org migration is not included here; this repo only contains the current static snapshot.

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -28,6 +28,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:39:43.736Z] [harness] The developer finished another implementation pass, so the port needs another review before we can move into testing. That step is necessary now because repeated implementation changes have to be rechecked against the approved plan before the rest of the pipeline can proceed safely.
 - [2026-04-20T11:38:51.674Z] [harness] The revised implementation still did not clear review, so it needs another correction pass before the test path can begin. That is the right move now because the port is close enough to keep iterating, but not yet ready to move forward.
 - [2026-04-20T11:38:14.499Z] [harness] The implementation was revised, so it needs to be checked again before testing can begin. That repeat review is necessary because the earlier pass did not clear the port against the approved plan, and we need to confirm the correction actually addressed that gap.
 - [2026-04-20T11:36:53.436Z] [harness] The implementation did not clear review, so it needs another pass before testing can begin. That retry is happening now because the review gate says the port is not yet aligned tightly enough with the approved plan.

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -22,6 +22,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:33:38.835Z] [harness] The conversion map is ready, so it needs a review before any implementation starts. That check is important now because we want to catch any drift from the original one-page experience before the new app structure is built on top of it.
 - [2026-04-20T11:33:15.363Z] [harness] The site inventory is done, so the next step is to turn that inventory into a concrete conversion map. That matters now because we need the exact list of preserved content and behaviors before anyone starts building the new app shape.
 - [2026-04-20T11:32:28.161Z] [harness] Dispatching Developer for phase 1 (inventory) of 12.
 - [2026-04-20T11:32:02.109Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -26,6 +26,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:38:14.499Z] [harness] The implementation was revised, so it needs to be checked again before testing can begin. That repeat review is necessary because the earlier pass did not clear the port against the approved plan, and we need to confirm the correction actually addressed that gap.
 - [2026-04-20T11:36:53.436Z] [harness] The implementation did not clear review, so it needs another pass before testing can begin. That retry is happening now because the review gate says the port is not yet aligned tightly enough with the approved plan.
 - [2026-04-20T11:36:10.503Z] [harness] The implementation step is finished, so it now needs an adherence check before the testing path starts. That review matters now because this is where we confirm the build still matches the approved port plan and did not drift into redesign.
 - [2026-04-20T11:34:13.778Z] [harness] The conversion plan cleared review, so the work can move from design into building the new app. That shift is happening now because the preserved content and structure have been agreed, and the next risk is implementation drift rather than planning.

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -1,0 +1,27 @@
+---
+status: doing
+labels: []
+created: "2026-04-20T11:30:59.085Z"
+started: "2026-04-20T11:30:59.085Z"
+completed: null
+github-pr: null
+github-comments: true
+no-pr: false
+depends-on: []
+---
+
+## Brief
+
+Port peterp.org to RedwoodSDK
+
+## Checklist
+
+## Progress Log
+
+
+
+
+- [2026-04-20T11:32:28.161Z] [harness] Dispatching Developer for phase 1 (inventory) of 12.
+- [2026-04-20T11:32:02.109Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
+- [2026-04-20T11:31:51.038Z] [harness] Updated draft PR with context from priming (title=true, body=true)
+- [2026-04-20T11:31:00.393Z] [harness] Understanding your codebase so agents have architectural context...

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -23,6 +23,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:34:13.778Z] [harness] The conversion plan cleared review, so the work can move from design into building the new app. That shift is happening now because the preserved content and structure have been agreed, and the next risk is implementation drift rather than planning.
 - [2026-04-20T11:33:38.835Z] [harness] The conversion map is ready, so it needs a review before any implementation starts. That check is important now because we want to catch any drift from the original one-page experience before the new app structure is built on top of it.
 - [2026-04-20T11:33:15.363Z] [harness] The site inventory is done, so the next step is to turn that inventory into a concrete conversion map. That matters now because we need the exact list of preserved content and behaviors before anyone starts building the new app shape.
 - [2026-04-20T11:32:28.161Z] [harness] Dispatching Developer for phase 1 (inventory) of 12.

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -27,6 +27,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:38:51.674Z] [harness] The revised implementation still did not clear review, so it needs another correction pass before the test path can begin. That is the right move now because the port is close enough to keep iterating, but not yet ready to move forward.
 - [2026-04-20T11:38:14.499Z] [harness] The implementation was revised, so it needs to be checked again before testing can begin. That repeat review is necessary because the earlier pass did not clear the port against the approved plan, and we need to confirm the correction actually addressed that gap.
 - [2026-04-20T11:36:53.436Z] [harness] The implementation did not clear review, so it needs another pass before testing can begin. That retry is happening now because the review gate says the port is not yet aligned tightly enough with the approved plan.
 - [2026-04-20T11:36:10.503Z] [harness] The implementation step is finished, so it now needs an adherence check before the testing path starts. That review matters now because this is where we confirm the build still matches the approved port plan and did not drift into redesign.

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -24,6 +24,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:36:10.503Z] [harness] The implementation step is finished, so it now needs an adherence check before the testing path starts. That review matters now because this is where we confirm the build still matches the approved port plan and did not drift into redesign.
 - [2026-04-20T11:34:13.778Z] [harness] The conversion plan cleared review, so the work can move from design into building the new app. That shift is happening now because the preserved content and structure have been agreed, and the next risk is implementation drift rather than planning.
 - [2026-04-20T11:33:38.835Z] [harness] The conversion map is ready, so it needs a review before any implementation starts. That check is important now because we want to catch any drift from the original one-page experience before the new app structure is built on top of it.
 - [2026-04-20T11:33:15.363Z] [harness] The site inventory is done, so the next step is to turn that inventory into a concrete conversion map. That matters now because we need the exact list of preserved content and behaviors before anyone starts building the new app shape.

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -25,6 +25,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:36:53.436Z] [harness] The implementation did not clear review, so it needs another pass before testing can begin. That retry is happening now because the review gate says the port is not yet aligned tightly enough with the approved plan.
 - [2026-04-20T11:36:10.503Z] [harness] The implementation step is finished, so it now needs an adherence check before the testing path starts. That review matters now because this is where we confirm the build still matches the approved port plan and did not drift into redesign.
 - [2026-04-20T11:34:13.778Z] [harness] The conversion plan cleared review, so the work can move from design into building the new app. That shift is happening now because the preserved content and structure have been agreed, and the next risk is implementation drift rather than planning.
 - [2026-04-20T11:33:38.835Z] [harness] The conversion map is ready, so it needs a review before any implementation starts. That check is important now because we want to catch any drift from the original one-page experience before the new app structure is built on top of it.

--- a/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
+++ b/.kindling/board/doing/2026-04-20-1330-port-peterp-org-to-redwoodsdk-b9de.md
@@ -21,6 +21,8 @@ Port peterp.org to RedwoodSDK
 
 
 
+
+- [2026-04-20T11:33:15.363Z] [harness] The site inventory is done, so the next step is to turn that inventory into a concrete conversion map. That matters now because we need the exact list of preserved content and behaviors before anyone starts building the new app shape.
 - [2026-04-20T11:32:28.161Z] [harness] Dispatching Developer for phase 1 (inventory) of 12.
 - [2026-04-20T11:32:02.109Z] [harness] Planning approach -- reading your brief, selecting protocol, assembling task force...
 - [2026-04-20T11:31:51.038Z] [harness] Updated draft PR with context from priming (title=true, body=true)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "rwsdk": "^0.0.0"
+    "rwsdk": "^0.3.6"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "peterp-org-redwoodsdk",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "release": "vite build"
+  },
+  "dependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "rwsdk": "^0.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@types/node": "^22.15.29",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/src/app/Document.tsx
+++ b/src/app/Document.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+type DocumentProps = {
+  children: ReactNode;
+};
+
+export function Document({ children }: DocumentProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta httpEquiv="X-UA-Compatible" content="ie=edge" />
+        <title>Peter Pistorius</title>
+        <style>{`
+          :root {
+            color-scheme: light;
+          }
+
+          html {
+            background: #fff;
+          }
+
+          body {
+            margin: 0;
+            font-family: serif;
+            max-width: 480px;
+            line-height: 1.6;
+            padding: 20px;
+            color: #111;
+            background: #fff;
+          }
+
+          a {
+            color: #0645ad;
+          }
+
+          a:visited {
+            color: #0b0080;
+          }
+        `}</style>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/pages/Home.tsx
+++ b/src/app/pages/Home.tsx
@@ -1,0 +1,54 @@
+const projects = [
+  {
+    href: "https://redwoodjs.com",
+    title: "RedwoodJS",
+    description: "Bringing full-stack to the JAMstack",
+  },
+  {
+    href: "https://machinen.dev",
+    title: "Machinen",
+    description: "Coming soon...",
+  },
+  {
+    href: "https://github.com/peterp/Blackspace",
+    title: "Blackspace",
+    description: "Add blank spaces to your macOS Dock",
+  },
+  {
+    href: "http://billable.me",
+    title: "Billable",
+    description: "Billing Made Simple. Period.",
+  },
+] as const;
+
+export function HomePage() {
+  return (
+    <>
+      <h1>Hi, my name is Peter.</h1>
+
+      <p>
+        I'm a South African living in Berlin. I love programming and it tends
+        to take all of my time, so I try to balance my life with friendship,
+        cycling, hiking and woodwork.
+      </p>
+
+      <p>
+        You can follow me on{" "}
+        <a href="https://twitter.com/appfactory/">Twitter</a>, or see my code
+        on <a href="https://github.com/peterp/">GitHub</a>.
+      </p>
+
+      <h2>Side Projects</h2>
+      <ol>
+        {projects.map((project) => (
+          <li key={project.title}>
+            <a href={project.href}>
+              <i>{project.title}</i>
+            </a>{" "}
+            &dash; {project.description}
+          </li>
+        ))}
+      </ol>
+    </>
+  );
+}

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -1,0 +1,9 @@
+import { defineApp } from "rwsdk/worker";
+import { render, route } from "rwsdk/router";
+
+import { Document } from "@/app/Document";
+import { HomePage } from "@/app/pages/Home";
+
+export default defineApp([
+  render(Document, [route("/", HomePage)]),
+]);

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -1,8 +1,8 @@
 import { defineApp } from "rwsdk/worker";
 import { render, route } from "rwsdk/router";
 
-import { Document } from "@/app/Document";
-import { HomePage } from "@/app/pages/Home";
+import { Document } from "@app/Document";
+import { HomePage } from "@app/pages/Home";
 
 export default defineApp([
   render(Document, [route("/", HomePage)]),

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -1,8 +1,8 @@
 import { defineApp } from "rwsdk/worker";
 import { render, route } from "rwsdk/router";
 
-import { Document } from "@app/Document";
-import { HomePage } from "@app/pages/Home";
+import { Document } from "@/app/Document";
+import { HomePage } from "@/app/pages/Home";
 
 export default defineApp([
   render(Document, [route("/", HomePage)]),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "noEmit": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,15 @@
 import { defineConfig } from "vite";
 import { fileURLToPath, URL } from "node:url";
 
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { redwood } from "rwsdk/vite";
 
 export default defineConfig({
-  environments: {
-    ssr: {},
-  },
   plugins: [
-    cloudflare({
-      viteEnvironment: { name: "worker" },
-    }),
     redwood(),
   ],
   resolve: {
     alias: {
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@app": fileURLToPath(new URL("./src/app", import.meta.url)),
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+import { fileURLToPath, URL } from "node:url";
+
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { redwood } from "rwsdk/vite";
+
+export default defineConfig({
+  environments: {
+    ssr: {},
+  },
+  plugins: [
+    cloudflare({
+      viteEnvironment: { name: "worker" },
+    }),
+    redwood(),
+  ],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@app": fileURLToPath(new URL("./src/app", import.meta.url)),
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
## Problem
The project started as a static single page site, which made it hard to evolve within the RedwoodSDK app structure while keeping the existing experience intact. This change was needed to move the site into a maintainable application format without altering the content, layout, metadata, or visible behavior users already expect. It also needed to preserve the current deployment setup so the port would not introduce operational drift.

## Solution
The site was rebuilt as a RedwoodSDK app and the existing experience was mapped into the new route, component, and document structure. The page content and presentation were carried over so the live result matches the original behavior as closely as possible. Supporting project configuration was added so the app builds and runs in the new setup while leaving the worker and deployment wiring unchanged.