### PR TITLE
Add GitHub Actions deploy workflow (#6)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Context

Closes #6.

## Details

Adds `.github/workflows/deploy.yml` which triggers on push to `master` and `workflow_dispatch`. The workflow:

1. Checks out the repo
2. Sets up pnpm v10 and Node 22
3. Runs `pnpm install --frozen-lockfile`
4. Runs `pnpm wrangler deploy` with `CLOUDFLARE_API_TOKEN` from repo secrets

## Verification

The workflow was produced by a kindling raw-protocol task (`kindling raw`, task 2026-04-21-1342-add-github-actions-deploy-workflow-ed22). Both Developer and Verifier independently ran it locally via agent-ci; every step before the deploy step passed; the `wrangler deploy` step failed on credential rejection as expected (Cloudflare secret not yet provisioned on this fork). That is the honest BLOCKED state per the issue's acceptance contract. Once `CLOUDFLARE_API_TOKEN` is added as a repo secret, pushes to master will deploy.

The task's GH_TOKEN lacked the `workflow` scope needed to push files under `.github/workflows/`, so the file was copied from the verified task container and pushed manually with a `workflow`-scoped token.